### PR TITLE
Ensure XeroImporter downloaded certificates

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Make sure Xero certificates were downloaded by XeroImporter
+if [ -f $1/config/certs/entrust-cert-2016.pem ]; then
+  echo "--- Found entrust-cert-2016.pem"
+  exit 0
+else
+  echo "Missing config/certs/entrust-cert-2016.pem"
+  exit 1
+fi


### PR DESCRIPTION
We import Xero certificates using `XeroImporter`, but we don't verify if they were actually downloaded.