### PR TITLE
Check whether private key exists instead

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,12 +10,12 @@ done
 cd $1
 bundle exec ./bin/post-deploy --path vendor/bundle
 
-# Make sure Xero certificates were downloaded by XeroImporter
-if [ -f "config/certs/entrust-cert.pem" ]; then
-  echo "--- Found entrust-cert.pem"
+# Make sure Xero private key is downloaded by XeroImporter
+if [ -f "config/certs/privatekey.pem" ]; then
+  echo "--- Found privatekey.pem"
   exit 0
 else
-  echo "Missing config/certs/entrust-cert.pem"
+  echo "Missing config/certs/privatekey.pem"
   exit 1
 fi
 


### PR DESCRIPTION
At some point, Xero will stop using certificates but we still need to have privatekey in there. So instead of checking the existence of certificate, we check the existence of private key